### PR TITLE
Fix GitHub actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "Build native libraries"
         if: steps.cache-libs.outputs.cache-hit != 'true'
         shell: bash
-        run: ./library.sh
+        run: ./library.sh "auto"
 
       - name: "Upload native libraries"
         uses: actions/upload-artifact@v2

--- a/library.sh
+++ b/library.sh
@@ -14,4 +14,6 @@ $SCRIPTS_DIRECTORY/c/library/main.sh \
     "" \
     "" \
 	
-read
+if [[ -z "$1" ]]; then
+    read
+fi


### PR DESCRIPTION
The previous PR added `read` to the end `library.sh` script so the output could be read by a user if someone went wrong. This however causes the GitHub Actions workflow to hang an timeout causing an exit code of non-zero leading to a failed state. This fixes this.